### PR TITLE
Prevent talk claims on legacy site

### DIFF
--- a/src/inc/js/talk.js
+++ b/src/inc/js/talk.js
@@ -33,10 +33,6 @@ talk = function (){
 					resizable: false,
 					modal: true,
 					buttons: {
-						"Yes, Proceed": function() {
-							window.location.href = $('#claim_btn').attr('href');
-							$( this ).dialog( "close" );
-						},
 						Cancel: function() {
 							$( this ).dialog( "close" );
 						}

--- a/src/system/application/controllers/talk.php
+++ b/src/system/application/controllers/talk.php
@@ -871,6 +871,13 @@ class Talk extends Controller
      */
     function claim($talkId, $claimId=null)
     {
+            $errorData = array(
+                'msg' => 'Talk claims have moved to the new Joind.in site! ' .
+                    'Please <a href="https://joind.in/">login to the new site</a> to claim';
+            );
+            $this->template->write_view('content', 'msg_error', $errorData);
+            $this->template->render();
+            return false;
         if ($claimId == null) {
             $claimId = $this->input->post('claim_name_select');
         }

--- a/src/system/application/views/talk/modules/_talk_buttons.php
+++ b/src/system/application/views/talk/modules/_talk_buttons.php
@@ -36,10 +36,8 @@
 </p>
 
 <div id="claim-dialog">
-    <p>By clicking this button you are declaring that you are the speaker responsible for it and a claim request will be sent to the administrator of the event.</p>
-    <p>If the claim is approved you will be able to edit the information for this talk.</p>
-    <p>Are you sure?</p>
-    
+    <p>Talk claims have been moved to the new <a href="https://joind.in">Joind.in site</a>.</p>
+    <p>Please login to the new site to claim your talk</p>    
 </div>
 <script type="text/javascript">
 $('#claim_select_div').css('display','none');


### PR DESCRIPTION
Having investigated an issue today, it appears that if a speaker claims a talk on legacy, it cannot be approved on web2.

This stops talk claims from being made on legacy, as talk claims should be made on web2 anyway.